### PR TITLE
feat: 为【更好的倒计日】组件设置精确的时间

### DIFF
--- a/ExtraIsland/Components/BetterCountdownSettings.xaml
+++ b/ExtraIsland/Components/BetterCountdownSettings.xaml
@@ -79,8 +79,8 @@
                     </Grid>  
                 </Grid>
             </materialDesign:Card>
-            <ci:SettingsCard IconGlyph="Calendar" Header="目标日期"
-                             Description="倒计时设定的日期">
+            <ci:SettingsCard IconGlyph="Calendar" Header="目标时间"
+                             Description="倒计时设定的日期和时间">
                 <ci:SettingsCard.Switcher>
                     <StackPanel Orientation="Horizontal">
                         <DatePicker SelectedDate="{Binding Settings.TargetDate, Mode=TwoWay}"

--- a/ExtraIsland/Components/BetterCountdownSettings.xaml
+++ b/ExtraIsland/Components/BetterCountdownSettings.xaml
@@ -82,10 +82,14 @@
             <ci:SettingsCard IconGlyph="Calendar" Header="目标日期"
                              Description="倒计时设定的日期">
                 <ci:SettingsCard.Switcher>
-                    <Grid>
+                    <StackPanel Orientation="Horizontal">
                         <DatePicker SelectedDate="{Binding Settings.TargetDate, Mode=TwoWay}"
                                     Margin="10 8 0 0" Width="120" />
-                    </Grid>
+                        <materialDesign:TimePicker Is24Hours="True"
+                                                   WithSeconds="True"
+                                                   SelectedTime="{Binding Settings.TargetDate, Mode=TwoWay}"
+                                                   Margin="4 8 0 0" Width="120" />
+                    </StackPanel>
                 </ci:SettingsCard.Switcher>
             </ci:SettingsCard>
             <ci:SettingsCard IconGlyph="Accelerometer" Header="时间精度"


### PR DESCRIPTION
考虑到以下几点：

1. 【更好的倒计日】组件最高可以显示精确到秒的倒计时
2. 【更好的倒计日】实际上使用 DateTime 属性存储倒计时截止时间，但设置界面只提供了日期设定选项

因此我在这个 PR 中为这个组件添加了设置具体时间的功能，以更好地利用这个组件能显示精确到秒的倒计时的特性。