### PR TITLE
feat: 为值日表添加节假日跳过功能，支持自动跳过国定假日和双休日

### DIFF
--- a/ExtraIsland/SettingPages/DutySettingsPage.xaml
+++ b/ExtraIsland/SettingPages/DutySettingsPage.xaml
@@ -1,0 +1,310 @@
+﻿<ci:SettingsPageBase x:Class="ExtraIsland.SettingsPages.DutySettingsPage"
+                     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                     xmlns:local="clr-namespace:ExtraIsland.SettingsPages"
+                     xmlns:ci="http://classisland.tech/schemas/xaml/core"
+                     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+                     xmlns:sc="clr-namespace:ExtraIsland.Shared.Converters"
+                     mc:Ignorable="d"
+                     Unloaded="DutySettingsPage_OnUnloaded"
+                     Title="DebugSettingsPage">
+    <ci:SettingsPageBase.Resources>
+        <sc:IntToStringConverter x:Key="IntToStringConverter"/>
+        <sc:DoubleToStringConverter x:Key="DoubleToStringConverter"/>
+        <sc:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />
+    </ci:SettingsPageBase.Resources>
+    <ScrollViewer DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=local:DutySettingsPage}}">
+        <!-- ReSharper disable once Xaml.StaticResourceNotResolved -->
+        <StackPanel Style="{StaticResource SettingsPageStackPanelStyle}">
+            <Label FontSize="20"
+                   VerticalAlignment="Center"
+                   Foreground="{DynamicResource MaterialDesignBodyLight}">
+                ExtraIsland
+            </Label>
+            <StackPanel Orientation="Horizontal">
+                <materialDesign:PackIcon
+                    Height="60"
+                    Width="60"
+                    Kind="Users"
+                    Foreground="{DynamicResource MaterialDesignBodyLight}"
+                    VerticalAlignment="Center" />
+                <Label VerticalAlignment="Center" FontSize="30">全局 · 值日表</Label>
+            </StackPanel>
+            <materialDesign:ColorZone Background="#1500F0F0" Panel.ZIndex="1" Margin="0 0 0 0" MaxWidth="670" HorizontalAlignment="Left">
+                <Grid>
+                    <DockPanel Margin="8 4">
+                        <materialDesign:PackIcon Kind="Warning"
+                                                 VerticalAlignment="Center"
+                                                 Height="20" Width="20"/>
+                        <TextBlock TextWrapping="Wrap"
+                                   VerticalAlignment="Center"
+                                   Margin="4 0 0 0" >
+                            <Run>该功能尚需改进，此功能在未来可能会产生较大的变动，并且</Run>
+                            <Bold>可能无法保证配置文件完全向下兼容。</Bold>
+                            <Run>要进行反馈交流,欢迎前往</Run>
+                            <ci:NavHyperlink CommandParameter="https://github.com/LiPolymer/ExtraIsland/discussions/8">
+                            <materialDesign:PackIcon
+                                VerticalAlignment="Center"
+                                Width="12"
+                                Height="12"
+                                Kind="Github"/>
+                            <materialDesign:PackIcon
+                                VerticalAlignment="Center"
+                                Width="12"
+                                Height="12"
+                                Kind="Message"/>
+                                LiPolymer/ExtraIsland #8
+                            </ci:NavHyperlink>
+                            <Run>!</Run>
+                        </TextBlock>
+                    </DockPanel>
+                </Grid>
+            </materialDesign:ColorZone>
+            <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                <materialDesign:Card Margin="0,6,0,6">
+                    <StackPanel Orientation="Vertical" Margin="12,6,10,6">
+                        <StackPanel Orientation="Horizontal">
+                            <materialDesign:PackIcon
+                                Height="{DynamicResource MainWindowLargeFontSize}"
+                                Width="{DynamicResource MainWindowLargeFontSize}"
+                                Kind="Users"
+                                Foreground="{DynamicResource MaterialDesignBody}"
+                                VerticalAlignment="Center" />
+                            <Label VerticalAlignment="Center"
+                                   FontSize="{DynamicResource MainWindowSecondaryFontSize}"
+                                   Margin="3">
+                                值日列表
+                            </Label>
+                            <materialDesign:Chip Background="{DynamicResource MaterialDesignDivider}"
+                                                 MaxWidth="300">
+                                <StackPanel Orientation="Horizontal">
+                                    <Label Content="当前索引" />
+                                    <Label x:Name="IndexOnDutyLabel" Content="{Binding Settings.Data.CurrentPeopleIndex}" />
+                                    <Label Content="@" />
+                                    <Label x:Name="PeopleOnDutyLabel" Content="{Binding PeopleOnDuty}" />
+                                </StackPanel>
+                            </materialDesign:Chip>
+                        </StackPanel>
+                        <StackPanel Orientation="Vertical" HorizontalAlignment="Center">
+                                <DataGrid x:Name="PeopleDataGrid"
+                                          Margin="6,6,6,0"
+                                          IsReadOnly="False"
+                                          AutoGenerateColumns="False"
+                                          CanUserResizeColumns="False"
+                                          CanUserReorderColumns="False"
+                                          CanUserAddRows="False"
+                                          SelectedCellsChanged="DataGrid_SelectedCellsChanged"
+                                          Height="240"
+                                          ItemsSource="{Binding Settings.Data.Peoples, Mode=TwoWay}">
+                                    <DataGrid.Columns>
+                                        <DataGridTextColumn Header="索引" Width="60" Binding="{Binding Index}" />
+                                        <DataGridTextColumn Header="姓名" Width="170" Binding="{Binding Name}" />
+                                        <DataGridTemplateColumn Header="操作" Width="60">
+                                            <DataGridTemplateColumn.CellTemplate>
+                                                <DataTemplate>
+                                                    <Button Width="20"
+                                                            Height="20"
+                                                            Margin="0"
+                                                            Padding="0"
+                                                            Background="Transparent"
+                                                            BorderBrush="Transparent"
+                                                            Click="DeleteButton_Click">
+                                                        <materialDesign:PackIcon Kind="Delete" Foreground="Red" />
+                                                    </Button>
+                                                </DataTemplate>
+                                            </DataGridTemplateColumn.CellTemplate>
+                                        </DataGridTemplateColumn>
+                                    </DataGrid.Columns>
+                                </DataGrid>
+                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch">
+                                <Button HorizontalAlignment="Left"
+                                        Width="30"
+                                        Height="30"
+                                        Margin="6,6,3,3"
+                                        Padding="0"
+                                        Background="{DynamicResource MaterialDesignDivider}"
+                                        BorderBrush="Transparent"
+                                        ToolTip="新建"
+                                        Click="AddButton_Click">
+                                    <materialDesign:PackIcon Kind="Add" Foreground="LightGreen" />
+                                </Button>
+                                <Button HorizontalAlignment="Left"
+                                        Width="30"
+                                        Height="30"
+                                        Margin="3,6,3,3"
+                                        Padding="0"
+                                        Background="{DynamicResource MaterialDesignDivider}"
+                                        BorderBrush="Transparent"
+                                        ToolTip="从文本文件导入"
+                                        Click="ImportButton_OnClick">
+                                    <materialDesign:PackIcon Kind="Import" Foreground="LightBlue" />
+                                </Button>
+                                <Button HorizontalAlignment="Left"
+                                        Width="30"
+                                        Height="30"
+                                        Margin="3,6,3,3"
+                                        Padding="0"
+                                        Background="{DynamicResource MaterialDesignDivider}"
+                                        BorderBrush="Transparent"
+                                        ToolTip="自动重新索引"
+                                        Click="AutoSort_OnClick">
+                                    <materialDesign:PackIcon Kind="Tags" Foreground="LightYellow" />
+                                </Button>
+                                <Button x:Name="DebugSwapButton"
+                                        HorizontalAlignment="Right"
+                                        Visibility = "Collapsed"
+                                        Width="30"
+                                        Height="30"
+                                        Margin="3,6,3,3"
+                                        Padding="0"
+                                        Background="{DynamicResource MaterialDesignDivider}"
+                                        BorderBrush="Transparent"
+                                        ToolTip="[Debug]手动触发交班"
+                                        Click="DebugButton_OnClick">
+                                    <materialDesign:PackIcon Kind="ShuffleVariant" Foreground="LightCyan" />
+                                </Button>
+                            </StackPanel>
+                        </StackPanel>
+                    </StackPanel>
+                </materialDesign:Card>
+                <!-- ReSharper disable once Xaml.StaticResourceNotResolved -->
+                <StackPanel Orientation="Vertical" Margin="8,6,0,0" Style="{StaticResource SettingsPageStackPanelStyle}">
+                    <materialDesign:Card Margin="0,0,0,6" Padding="7,0,0,0" Height="30">
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
+                            <Label>上次更新</Label>
+                            <Label x:Name="LastUpdateLabel"/>
+                            <Button Click="ClearTimeButton_OnClick"
+                                    Background="Transparent"
+                                    BorderBrush="Transparent"
+                                    Foreground="{DynamicResource PrimaryHueLightBrush}"
+                                    ToolTip="时间抹零"
+                                    Padding="3,0,3,0"
+                                    Height="20">
+                                <materialDesign:PackIcon
+                                    Kind="DeleteClock"/>
+                            </Button>
+                        </StackPanel>
+                    </materialDesign:Card>
+                    <ci:SettingsCard IconGlyph="ScissorsCutting"
+                                     Header="自动时间抹零"
+                                     Description="开启后,每次更新都将只记录日期数据"
+                                     IsOn="{Binding Settings.Data.IsAutoShearEnabled, Mode=TwoWay}"/>
+                    <ci:SettingsCard IconGlyph="Restart"
+                                     Header="循环"
+                                     Description="开启后,每当列表遍历完毕,索引将自动归零"
+                                     IsOn="{Binding Settings.Data.IsCycled, Mode=TwoWay}"/>
+                    
+                    <!-- 节假日跳过功能 -->
+                    <materialDesign:Card Margin="0 0 0 6">
+                        <Expander Background="Transparent"
+                                  IsExpanded="{Binding Settings.Data.IsHolidaySkipEnabled, Mode=OneWay}"
+                                  TextBlock.Foreground="{DynamicResource MaterialDesignBody}">
+                            <Expander.Header>
+                                <ci:SettingsControl IconGlyph="CalendarWeekend"
+                                                    Header="自动跳过节假日"
+                                                    Description="自动跳过国定假日和双休日的值日轮换"
+                                                    HasSwitcher="True"
+                                                    IsOn="{Binding Settings.Data.IsHolidaySkipEnabled, Mode=TwoWay}"
+                                                    Margin="-12 0" />
+                            </Expander.Header>
+                            <!-- ReSharper disable once Xaml.StaticResourceNotResolved -->
+                            <StackPanel Orientation="Vertical" Style="{StaticResource SettingsPageStackPanelStyle}">
+                                <ci:SettingsControl IconGlyph="CalendarClock"
+                                                    Header="节假日跳过历史"
+                                                    Description="上次跳过的节假日信息"
+                                                    HasSwitcher="False"
+                                                    Margin="12,0,6,6" />
+                                <!-- 上次跳过的节假日信息 -->
+                                <Border Background="{DynamicResource MaterialDesignDivider}"
+                                        Margin="30,0,0,6"
+                                        CornerRadius="5"
+                                        Padding="8,4">
+                                    <TextBlock x:Name="LastSkippedHolidayLabel"
+                                               Foreground="{DynamicResource MaterialDesignBody}"
+                                               TextWrapping="Wrap"
+                                               Text="上次跳过的节假日：暂无&#x0a;索引变化：- → -" />
+                                </Border>
+                                
+                                <ci:SettingsControl IconGlyph="CalendarCheckOutline"
+                                                    Header="即将跳过的节假日"
+                                                    Description="下一个将要跳过的节假日"
+                                                    HasSwitcher="False"
+                                                    Margin="12,6,6,6" />
+                                <!-- 即将跳过的节假日信息 -->
+                                <Border Background="{DynamicResource MaterialDesignDivider}"
+                                        Margin="30,0,0,6"
+                                        CornerRadius="5"
+                                        Padding="8,4">
+                                    <TextBlock x:Name="NextHolidayLabel"
+                                               Foreground="{DynamicResource MaterialDesignBody}"
+                                               Text="即将跳过的节假日：查询中..." />
+                                </Border>
+                                
+                                <ci:SettingsControl IconGlyph="InformationOutline"
+                                                    Header="功能说明"
+                                                    Description="节假日数据来源及使用说明"
+                                                    HasSwitcher="False"
+                                                    Margin="12,6,6,6" />
+                                <!-- 功能说明 -->
+                                <Border Background="{DynamicResource MaterialDesignDivider}"
+                                        Margin="30,0,0,6"
+                                        CornerRadius="5"
+                                        Padding="8,4">
+                                    <TextBlock Foreground="{DynamicResource MaterialDesignBody}"
+                                               TextWrapping="Wrap"
+                                               Text="• 节假日数据来源：timor.tech API&#x0a;• 自动跳过国定假日、调休日和双休日&#x0a;• 支持多日未启动程序的补全机制&#x0a;• 数据缓存，减少网络请求" />
+                                </Border>
+                            </StackPanel>
+                        </Expander>
+                    </materialDesign:Card>
+                    
+                    <ci:SettingsCard IconGlyph="Numbers"
+                                     Header="索引"
+                                     Description="手动修改当前索引">
+                        <ci:SettingsCard.Switcher>
+                            <TextBox Grid.Column="5"
+                                     MinWidth="20"
+                                     HorizontalContentAlignment="Center"
+                                     Margin="3,0,6,0"
+                                     InputMethod.IsInputMethodEnabled="False"
+                                     PreviewTextInput="TextBoxNumberCheck"
+                                     Text="{Binding Settings.Data.CurrentPeopleIndex, Converter={StaticResource IntToStringConverter}}"/>
+                        </ci:SettingsCard.Switcher>
+                    </ci:SettingsCard>
+                    <ci:SettingsCard IconGlyph="Stopwatch"
+                                     Header="轮换间隔"
+                                     Description="轮换到下一位间隔的天数">
+                        <ci:SettingsCard.Switcher>
+                            <TextBox Grid.Column="5"
+                                     MinWidth="20"
+                                     HorizontalContentAlignment="Center"
+                                     Margin="3,0,6,0"
+                                     InputMethod.IsInputMethodEnabled="False"
+                                     PreviewTextInput="TextBoxNumberCheck"
+                                     Text="{Binding Settings.Data.DutyChangeDurationDays, Converter={StaticResource DoubleToStringConverter}}"/>
+                        </ci:SettingsCard.Switcher>
+                    </ci:SettingsCard>
+                    <ci:SettingsCard IconGlyph="SwitchAccount" Header="轮换方式"
+                                     Description="选择值日生轮换方法">
+                        <ci:SettingsCard.Switcher>
+                            <Grid>
+                                <ComboBox
+                                    MinWidth="20"
+                                    SelectedItem="{Binding Settings.Data.DutyState}"
+                                    ItemsSource="{Binding DutyStates}">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}" />
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
+                            </Grid>
+                        </ci:SettingsCard.Switcher>
+                    </ci:SettingsCard>
+                </StackPanel>
+            </StackPanel>
+        </StackPanel>
+    </ScrollViewer>
+</ci:SettingsPageBase>

--- a/ExtraIsland/SettingPages/DutySettingsPage.xaml.cs
+++ b/ExtraIsland/SettingPages/DutySettingsPage.xaml.cs
@@ -1,0 +1,202 @@
+﻿using System.Collections.ObjectModel;
+using System.IO;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using ClassIsland.Core.Attributes;
+using ExtraIsland.ConfigHandlers;
+using ExtraIsland.Shared;
+using MahApps.Metro.Controls;
+using MaterialDesignThemes.Wpf;
+using Microsoft.Win32;
+
+namespace ExtraIsland.SettingsPages;
+
+[SettingsPageInfo("extraisland.duty","ExtraIsland·值日",PackIconKind.UsersOutline,PackIconKind.Users)]
+public partial class DutySettingsPage {
+    private bool _isUpdatingHolidayInfo = false; // 防止循环更新的标志
+
+    public DutySettingsPage() {
+        Settings = GlobalConstants.Handlers.OnDuty!;
+        InitializeComponent();
+        UpdateOnDuty();
+        UpdateHolidayInfo();
+        Settings.OnDutyUpdated += UpdateOnDuty;
+        Settings.Data.PropertyChanged += OnDataPropertyChanged;
+        #if DEBUG
+            DebugSwapButton.Visibility = Visibility.Visible;
+        #endif
+    }
+
+    public OnDutyPersistedConfigHandler Settings { get; set; }
+    
+    public string PeopleOnDuty { get; set; } = string.Empty;
+
+    void DutySettingsPage_OnUnloaded(object sender,RoutedEventArgs e) {
+        Settings.OnDutyUpdated -= UpdateOnDuty;
+        Settings.Data.PropertyChanged -= OnDataPropertyChanged;
+        Settings.Save();
+    }
+    
+    void OnDataPropertyChanged() {
+        // 防止循环更新，只在节假日功能开启且当前没有正在更新时才执行
+        if (Settings.Data.IsHolidaySkipEnabled && !_isUpdatingHolidayInfo) {
+            UpdateHolidayInfo();
+        }
+    }
+    
+    void DataGrid_SelectedCellsChanged(object sender,SelectedCellsChangedEventArgs e) {
+        Settings.Save();
+    }
+    void DeleteButton_Click(object sender,RoutedEventArgs e) {
+        Button button = (sender as Button)!;
+        if (button.DataContext is OnDutyPersistedConfigData.PeopleItem peopleItem) {
+            Settings.Data.Peoples.Remove(peopleItem);
+        }
+    }
+
+    void AddButton_Click(object sender, RoutedEventArgs e) {
+        Settings.Data.Peoples.Add(new OnDutyPersistedConfigData.PeopleItem {
+            Index = Settings.Data.Peoples.Count,
+            Name = "新同学"
+        });
+        Settings.Save();
+    }
+
+    void UpdateOnDuty() {
+        this.Invoke(() => {
+            IndexOnDutyLabel.Content = Settings.Data.CurrentPeopleIndex.ToString();
+            PeopleOnDutyLabel.Content = Settings.PeoplesOnDutyString;
+            LastUpdateLabel.Content = Settings.LastUpdateString;
+        });
+    }
+    
+    /// <summary>
+    /// 更新节假日相关信息显示
+    /// </summary>
+    async void UpdateHolidayInfo() {
+        if (!Settings.Data.IsHolidaySkipEnabled || _isUpdatingHolidayInfo) {
+            return;
+        }
+        
+        _isUpdatingHolidayInfo = true;
+        
+        try {
+            // 异步获取下一个节假日信息
+            _ = Task.Run(async () => {
+                try {
+                    var nextHoliday = await HolidayService.GetNextHolidayAsync(DateTime.Today);
+                    
+                    this.BeginInvoke(() => {
+                        try {
+                            if (nextHoliday.HasValue) {
+                                NextHolidayLabel.Text = $"即将跳过的节假日：{nextHoliday.Value.Name}";
+                            } else {
+                                NextHolidayLabel.Text = "即将跳过的节假日：暂无";
+                            }
+                        }
+                        catch {
+                            // UI已被释放时忽略错误
+                        }
+                    });
+                }
+                catch {
+                    // 网络请求失败时的处理
+                    this.BeginInvoke(() => {
+                        try {
+                            NextHolidayLabel.Text = "即将跳过的节假日：获取失败";
+                        }
+                        catch {
+                            // UI已被释放时忽略错误
+                        }
+                    });
+                }
+            });
+            
+            // 更新界面显示
+            this.Invoke(() => {
+                try {
+                    // 更新上次跳过的节假日信息显示
+                    if (string.IsNullOrEmpty(Settings.Data.LastSkippedHoliday)) {
+                        LastSkippedHolidayLabel.Text = "上次跳过的节假日：暂无\n索引变化：- → -";
+                    } else {
+                        LastSkippedHolidayLabel.Text = $"上次跳过的节假日：{Settings.Data.LastSkippedHoliday}\n索引变化：{Settings.Data.LastSkippedOriginalIndex} → {Settings.Data.LastSkippedNewIndex}";
+                    }
+                    
+                    // 更新下一个节假日信息显示
+                    var nextHolidayName = string.IsNullOrEmpty(Settings.Data.NextHolidayName) ? "查询中..." : Settings.Data.NextHolidayName;
+                    NextHolidayLabel.Text = $"即将跳过的节假日：{nextHolidayName}";
+                }
+                catch {
+                    // UI已被释放时忽略错误
+                }
+            });
+        }
+        finally {
+            _isUpdatingHolidayInfo = false;
+        }
+    }
+    
+    [GeneratedRegex("[^0-9]+")]
+    private static partial Regex NumberRegex();
+    void TextBoxNumberCheck(object sender,TextCompositionEventArgs e) {
+        Regex re = NumberRegex();
+        e.Handled = re.IsMatch(e.Text);
+    }
+    
+    public List<OnDutyPersistedConfigData.DutyStateData> DutyStates { get; } = [
+        OnDutyPersistedConfigData.DutyStateData.Single,
+        OnDutyPersistedConfigData.DutyStateData.Double,
+        OnDutyPersistedConfigData.DutyStateData.InOut,
+        OnDutyPersistedConfigData.DutyStateData.Quadrant
+    ];
+
+    void ClearTimeButton_OnClick(object sender,RoutedEventArgs e) {
+        Settings.Data.LastUpdate = Settings.Data.LastUpdate.Date;
+    }
+    void ImportButton_OnClick(object sender,RoutedEventArgs e) {
+        OpenFileDialog dialog = new Microsoft.Win32.OpenFileDialog {
+            DefaultExt = ".txt",
+            Filter = "文本文档 (.txt)|*.txt"
+        };
+        bool? result = dialog.ShowDialog();
+        if (result != true) return;
+        string[] list = File.ReadAllLines(dialog.FileName);
+        ObservableCollection<OnDutyPersistedConfigData.PeopleItem> peoples = [];
+        int i = 0;
+        foreach (string name in list) {
+            peoples.Add(new OnDutyPersistedConfigData.PeopleItem {
+                Index = i,
+                Name = name
+            });
+            i++;
+        }
+        Settings.Data.Peoples = peoples;
+        PeopleDataGrid.ItemsSource = Settings.Data.Peoples;
+    }
+    void DebugButton_OnClick(object sender,RoutedEventArgs e) {
+        if (Settings.Data.IsHolidaySkipEnabled) {
+            // 使用带节假日跳过的轮换方法
+            Task.Run(async () => {
+                try {
+                    await Settings.SwapOnDutyWithHolidaySkipAsync();
+                    this.BeginInvoke(() => {
+                        Settings.UpdateOnDuty();
+                        UpdateHolidayInfo();
+                    });
+                }
+                catch {
+                    // 忽略错误
+                }
+            });
+        } else {
+            // 使用传统轮换方法
+            Settings.SwapOnDuty();
+        }
+    }
+    void AutoSort_OnClick(object sender,RoutedEventArgs e) {
+        Settings.SortCollectionByIndex();
+        PeopleDataGrid.ItemsSource = Settings.Data.Peoples;
+    }
+}

--- a/ExtraIsland/Shared/HolidayService.cs
+++ b/ExtraIsland/Shared/HolidayService.cs
@@ -1,0 +1,188 @@
+﻿using System.Net.Http;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.Logging;
+
+namespace ExtraIsland.Shared;
+
+/// <summary>
+/// 节假日服务，用于获取和判断节假日信息
+/// </summary>
+public static class HolidayService {
+    private static readonly Dictionary<int, YearHolidayData> CachedHolidays = new();
+    private static readonly SemaphoreSlim CacheLock = new(1, 1);
+    
+    /// <summary>
+    /// 判断指定日期是否为节假日（包括双休日）
+    /// </summary>
+    /// <param name="date">要判断的日期</param>
+    /// <returns>如果是节假日返回true，否则返回false</returns>
+    public static async Task<bool> IsHolidayAsync(DateTime date) {
+        // 首先检查是否为周末
+        if (IsWeekend(date)) {
+            return true;
+        }
+        
+        // 获取该年份的节假日数据
+        var yearData = await GetYearHolidayDataAsync(date.Year);
+        if (yearData == null) {
+            return false; // 如果无法获取数据，默认不是节假日
+        }
+        
+        // 检查是否为节假日
+        var dateKey = date.ToString("MM-dd");
+        if (yearData.Holiday?.ContainsKey(dateKey) == true) {
+            var holidayInfo = yearData.Holiday[dateKey];
+            return holidayInfo.Holiday; // true为节假日，false为调休工作日
+        }
+        
+        return false;
+    }
+    
+    /// <summary>
+    /// 获取指定日期的节假日信息
+    /// </summary>
+    /// <param name="date">要查询的日期</param>
+    /// <returns>节假日信息，如果不是节假日则返回null</returns>
+    public static async Task<HolidayInfo?> GetHolidayInfoAsync(DateTime date) {
+        if (IsWeekend(date)) {
+            return new HolidayInfo {
+                Holiday = true,
+                Name = GetWeekendName(date),
+                Wage = 1,
+                Date = date.ToString("yyyy-MM-dd"),
+                Rest = 0
+            };
+        }
+        
+        var yearData = await GetYearHolidayDataAsync(date.Year);
+        if (yearData?.Holiday == null) {
+            return null;
+        }
+        
+        var dateKey = date.ToString("MM-dd");
+        if (yearData.Holiday.ContainsKey(dateKey)) {
+            var holidayInfo = yearData.Holiday[dateKey];
+            if (holidayInfo.Holiday) {
+                return holidayInfo;
+            }
+        }
+        
+        return null;
+    }
+    
+    /// <summary>
+    /// 获取指定年份下一个节假日的信息
+    /// </summary>
+    /// <param name="fromDate">起始日期</param>
+    /// <returns>下一个节假日信息</returns>
+    public static async Task<(DateTime Date, string Name)?> GetNextHolidayAsync(DateTime fromDate) {
+        // 检查从明天开始的未来一年内的日期
+        for (int i = 1; i <= 365; i++) {
+            var checkDate = fromDate.Date.AddDays(i);
+            var holidayInfo = await GetHolidayInfoAsync(checkDate);
+            
+            if (holidayInfo != null) {
+                return (checkDate, holidayInfo.Name);
+            }
+        }
+        
+        return null;
+    }
+    
+    /// <summary>
+    /// 获取指定年份的节假日数据
+    /// </summary>
+    /// <param name="year">年份</param>
+    /// <returns>节假日数据</returns>
+    private static async Task<YearHolidayData?> GetYearHolidayDataAsync(int year) {
+        await CacheLock.WaitAsync();
+        try {
+            // 检查缓存
+            if (CachedHolidays.TryGetValue(year, out var cached)) {
+                return cached;
+            }
+            
+            // 从API获取数据
+            using var httpClient = new HttpClient();
+            httpClient.Timeout = TimeSpan.FromSeconds(10);
+            
+            try {
+                var response = await httpClient.GetStringAsync($"https://timor.tech/api/holiday/year/{year}");
+                var data = JsonSerializer.Deserialize<YearHolidayData>(response);
+                
+                if (data != null) {
+                    CachedHolidays[year] = data;
+                    return data;
+                }
+            }
+            catch (Exception ex) {
+                // 记录错误但不抛出异常，让程序继续运行
+                try {
+                    GlobalConstants.HostInterfaces.PluginLogger?.LogInformation($"获取节假日数据失败: {ex.Message}");
+                }
+                catch {
+                    // 忽略日志记录错误
+                }
+            }
+            
+            return null;
+        }
+        finally {
+            CacheLock.Release();
+        }
+    }
+    
+    /// <summary>
+    /// 判断是否为周末
+    /// </summary>
+    /// <param name="date">日期</param>
+    /// <returns>是否为周末</returns>
+    private static bool IsWeekend(DateTime date) {
+        return date.DayOfWeek == DayOfWeek.Saturday || date.DayOfWeek == DayOfWeek.Sunday;
+    }
+    
+    /// <summary>
+    /// 获取周末名称
+    /// </summary>
+    /// <param name="date">日期</param>
+    /// <returns>周末名称</returns>
+    private static string GetWeekendName(DateTime date) {
+        return date.DayOfWeek switch {
+            DayOfWeek.Saturday => "周六",
+            DayOfWeek.Sunday => "周日",
+            _ => "周末"
+        };
+    }
+}
+
+/// <summary>
+/// 年度节假日数据
+/// </summary>
+public class YearHolidayData {
+    [JsonPropertyName("code")]
+    public int Code { get; set; }
+    
+    [JsonPropertyName("holiday")]
+    public Dictionary<string, HolidayInfo>? Holiday { get; set; }
+}
+
+/// <summary>
+/// 节假日信息
+/// </summary>
+public class HolidayInfo {
+    [JsonPropertyName("holiday")]
+    public bool Holiday { get; set; }
+    
+    [JsonPropertyName("name")]
+    public string Name { get; set; } = string.Empty;
+    
+    [JsonPropertyName("wage")]
+    public int Wage { get; set; }
+    
+    [JsonPropertyName("date")]
+    public string Date { get; set; } = string.Empty;
+    
+    [JsonPropertyName("rest")]
+    public int Rest { get; set; }
+}


### PR DESCRIPTION
# 值日表自动跳过国定假日（含双休日）的轮换功能

_made by xingbiao996 with **Github Copilot** ()_

自动跳过国定假日（含双休日）的轮换功能。

使用了 `https://timor.tech/api/holiday` 的 `API` 。

- 正确处理调休日的特殊情况

- 优化多日未启动程序时的索引处理机制：

- 准确计算并补全期间所有应轮换的日期

- 支持显示  
上次跳过的节假日：{节假日名称} {原索引} → {新索引}  
即将跳过的节假日：{节假日名称}

