### PR TITLE
feat: "更好的倒计时"通知信息支持在"设置-通知"中修改

### DIFF
--- a/ExtraIsland/Components/BetterCountdown/BetterCountdown.axaml.cs
+++ b/ExtraIsland/Components/BetterCountdown/BetterCountdown.axaml.cs
@@ -201,7 +201,7 @@ public partial class BetterCountdown : ComponentBase<BetterCountdownConfig> {
     }
 
     void Notify() {
-        TimeUpNotification.Notify(string.Format(Settings.Message, Settings.Prefix, Settings.Suffix),
+        BetterCountdownNotification.Notify(Settings.Name, Settings.Message,
                                   Settings.LeftIcon, Settings.RightIcon);
         Settings.IsNotified = true;
     }

--- a/ExtraIsland/Components/BetterCountdown/BetterCountdownConfig.cs
+++ b/ExtraIsland/Components/BetterCountdown/BetterCountdownConfig.cs
@@ -81,7 +81,8 @@ public class BetterCountdownConfig : ObservableObject {
     public bool IsFocusedModeEnabled { get; set; }
     public bool IsNotify {get; set;}
 
-    public string Message { get; set; } = "{0} 已结束";
+    public string Name {get; set;} = "倒计时名称";
+    public string Message { get; set; } = "";
 
     public string LeftIcon { get; set; } = "\uE352";
     

--- a/ExtraIsland/Components/BetterCountdown/BetterCountdownSettings.axaml
+++ b/ExtraIsland/Components/BetterCountdown/BetterCountdownSettings.axaml
@@ -163,14 +163,23 @@
             </controls:SettingsExpander>
             <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE4D4;}"
                                        Header="启用提醒"
-                                       Description="启用后,倒计时到后将进行提醒">
+                                       Description="启用后,倒计时到后将进行提醒，显示格式为{事件名称}{提醒消息}">
                 <controls:SettingsExpander.Footer>
                     <ToggleSwitch IsChecked="{Binding Settings.IsNotify, Mode=TwoWay}"/>
                 </controls:SettingsExpander.Footer>
                 <controls:SettingsExpander.Items>
+                    <controls:SettingsExpanderItem IconSource="{ci:FluentIconSource &#xE8AC;}"
+                                                   Content="事件名称"
+                                                   Description="提醒事件名称">
+                        <controls:SettingsExpanderItem.Footer>
+                            <TextBox Text="{Binding Settings.Name, Mode=TwoWay}" />
+                        </controls:SettingsExpanderItem.Footer>
+                    </controls:SettingsExpanderItem>
+                </controls:SettingsExpander.Items>
+                <controls:SettingsExpander.Items>
                         <controls:SettingsExpanderItem IconSource="{ci:FluentIconSource &#xE8AC;}"
-                                                       Content="编辑提醒"
-                                                       Description="修改提醒的文字, 可以用 {0} {1} 分别指代前缀和后缀">
+                                                       Content="提醒消息"
+                                                       Description="修改提醒消息的文案, 留空以继承‘提醒渠道’中的设置">
                             <controls:SettingsExpanderItem.Footer>
                                 <TextBox Text="{Binding Settings.Message, Mode=TwoWay}" />
                             </controls:SettingsExpanderItem.Footer>

--- a/ExtraIsland/Notification/BetterCountdownNotification.cs
+++ b/ExtraIsland/Notification/BetterCountdownNotification.cs
@@ -1,7 +1,6 @@
 ﻿using ClassIsland.Core.Abstractions.Services.NotificationProviders;
 using ClassIsland.Core.Attributes;
 using ClassIsland.Core.Models.Notification;
-using ExtraIsland.Components;
 
 namespace ExtraIsland.Notification;
 
@@ -13,27 +12,27 @@ namespace ExtraIsland.Notification;
 [NotificationChannelInfo(
     TimeUpChannelId,
     "倒计时结束",
-    "\u1000",
+    "\uE84C",
     "倒计时结束后的提醒")]
-public class TimeUpNotification : NotificationProviderBase {
+public class BetterCountdownNotification : NotificationProviderBase<BetterCountdownNotificationSettings> {
 
     const string TimeUpChannelId = "40f73a64-a0d8-480b-8026-f0a71a14d6fb";
 
-    delegate void TwoIconsMaskNotify(string content, string leftIcon, string rightIcon);
+    delegate void TwoIconsMaskNotify(string name, string message, string leftIcon, string rightIcon);
     
     static event TwoIconsMaskNotify? OnNotify;
 
-    public static void Notify(string content, string leftIcon = "", string rightIcon = "") {
-        OnNotify?.Invoke(content, leftIcon, rightIcon);
+    public static void Notify(string name, string message, string leftIcon = "", string rightIcon = "") {
+        OnNotify?.Invoke(name, message, leftIcon, rightIcon);
     }
     
-    public TimeUpNotification() {
+    public BetterCountdownNotification() {
         OnNotify += DoNotify;
     }
     
-    void DoNotify(string content, string leftIcon, string rightIcon) {
+    void DoNotify(string name, string content, string leftIcon, string rightIcon) {
         Channel(TimeUpChannelId).ShowNotification(new NotificationRequest() {
-            MaskContent = NotificationContent.CreateTwoIconsMask(content, leftIcon, rightIcon)
+            MaskContent = NotificationContent.CreateTwoIconsMask(content==""?name+Settings.Message:name+content, leftIcon, rightIcon)
         });
     }
 }

--- a/ExtraIsland/Notification/BetterCountdownNotificationSettings.cs
+++ b/ExtraIsland/Notification/BetterCountdownNotificationSettings.cs
@@ -1,0 +1,11 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace ExtraIsland.Notification;
+
+public class BetterCountdownNotificationSettings : ObservableRecipient{
+    string _message = "的时间到了";
+    public string Message {
+        get => _message;
+        set => SetProperty(ref _message, value);
+    }
+}

--- a/ExtraIsland/Notification/BetterCountdownNotificationSettingsControl.axaml
+++ b/ExtraIsland/Notification/BetterCountdownNotificationSettingsControl.axaml
@@ -1,0 +1,24 @@
+﻿<ci:NotificationProviderControlBase
+    x:Class="ExtraIsland.Notification.BetterCountdownNotificationSettingsControl"
+    x:TypeArguments="local:BetterCountdownNotificationSettings"
+    xmlns="https://github.com/avaloniaui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:ci="http://classisland.tech/schemas/xaml/core"
+    xmlns:local="clr-namespace:ExtraIsland.Notification"
+    xmlns:controls="clr-namespace:FluentAvalonia.UI.Controls;assembly=FluentAvalonia"
+    mc:Ignorable="d"
+    d:DesignHeight="300" d:DesignWidth="300">
+    <StackPanel DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType=local:BetterCountdownNotificationSettingsControl}}">
+        <ScrollViewer Margin="0">
+            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE4BD;}"
+                                       Header="提醒文案"
+                                       Description="提醒内容的后半段文案,可被组件设置中覆盖">
+                <controls:SettingsExpander.Footer>
+                    <TextBox Text="{Binding Settings.Message, Mode=TwoWay}"></TextBox>
+                </controls:SettingsExpander.Footer>
+            </controls:SettingsExpander>
+        </ScrollViewer>
+    </StackPanel>
+</ci:NotificationProviderControlBase>

--- a/ExtraIsland/Notification/BetterCountdownNotificationSettingsControl.axaml.cs
+++ b/ExtraIsland/Notification/BetterCountdownNotificationSettingsControl.axaml.cs
@@ -1,0 +1,13 @@
+﻿using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+using ClassIsland.Core.Abstractions.Controls;
+using ClassIsland.Core.Abstractions.Services.NotificationProviders;
+
+namespace ExtraIsland.Notification;
+
+public partial class BetterCountdownNotificationSettingsControl :NotificationProviderControlBase<BetterCountdownNotificationSettings> {
+    public BetterCountdownNotificationSettingsControl() {
+        InitializeComponent();
+    }
+}

--- a/ExtraIsland/Plugin.cs
+++ b/ExtraIsland/Plugin.cs
@@ -123,7 +123,7 @@ public class Plugin : PluginBase {
         }
         
         //NotificationProvider
-        services.AddNotificationProvider<TimeUpNotification>();
+        services.AddNotificationProvider<BetterCountdownNotification, BetterCountdownNotificationSettingsControl>();
         
         //Actions
         Register.Claim(services);


### PR DESCRIPTION
现在通知内容可以在"提醒提供方"设置中修改了
支持继承功能，即组件设置中"提醒消息"选项留空时，自动使用提醒提供方中的设置
目前官方文档中暂未看到如何创建提醒渠道设置页面，故无法使用，请见谅

<img width="1552" height="726" alt="屏幕截图 2026-02-19 164648" src="https://github.com/user-attachments/assets/97d641b9-1eaa-4a81-9fd1-17001162d6da" />
<img width="1552" height="726" alt="屏幕截图 2026-02-19 164509" src="https://github.com/user-attachments/assets/8edb159b-c69e-47b4-9901-11990a36c652" />

