### PR TITLE
feat: 添加每周第一天设置选项

### DIFF
--- a/ExtraIsland/Components/ProfileInformation/ProfileInformation.axaml.cs
+++ b/ExtraIsland/Components/ProfileInformation/ProfileInformation.axaml.cs
@@ -55,14 +55,32 @@ public partial class ProfileInformation : ComponentBase<ProfileInformationConfig
     int GetWeekInSemester(DateTime? current = null) {
         current ??= _exactTimeService.GetCurrentLocalDateTime();
         DateTime orientation = (DateTime)((dynamic)AppBase.Current).Settings.SingleWeekStartTime;
-        int oriWeek = orientation.DayOfWeek == DayOfWeek.Sunday ? 6 : Convert.ToInt32(orientation.DayOfWeek) - 1;
         
-        //regulate
-        DateTime startMonday = orientation.AddDays(-oriWeek);
-        int lastDelta = current.Value.DayOfWeek != DayOfWeek.Sunday ? 7 - Convert.ToInt32(current.Value.DayOfWeek) : 0;
-        DateTime lastEnd = current.Value.AddDays(lastDelta);
+        // 计算学期开始时间所在周的第一天（根据配置）
+        DayOfWeek firstDayOfWeek = ConvertToDayOfWeek(Settings.FirstDayOfWeek);
         
-        TimeSpan totalWeekDelta = lastEnd - startMonday;
+        // 计算从学期开始日期到本周第一天的天数差
+        int daysToStartOfWeek = ((int)orientation.DayOfWeek - (int)firstDayOfWeek + 7) % 7;
+        DateTime startDay = orientation.AddDays(-daysToStartOfWeek);
+        
+        // 计算当前日期所在周的最后一天
+        int daysToEndOfWeek = ((int)firstDayOfWeek - (int)current.Value.DayOfWeek + 6) % 7;
+        DateTime lastEnd = current.Value.AddDays(daysToEndOfWeek);
+        
+        TimeSpan totalWeekDelta = lastEnd - startDay;
         return Convert.ToInt32(totalWeekDelta.Days + 1) / 7;
+    }
+    
+    DayOfWeek ConvertToDayOfWeek(FirstDayOfWeek firstDayOfWeek) {
+        return firstDayOfWeek switch {
+            FirstDayOfWeek.Sunday => DayOfWeek.Sunday,
+            FirstDayOfWeek.Monday => DayOfWeek.Monday,
+            FirstDayOfWeek.Tuesday => DayOfWeek.Tuesday,
+            FirstDayOfWeek.Wednesday => DayOfWeek.Wednesday,
+            FirstDayOfWeek.Thursday => DayOfWeek.Thursday,
+            FirstDayOfWeek.Friday => DayOfWeek.Friday,
+            FirstDayOfWeek.Saturday => DayOfWeek.Saturday,
+            _ => DayOfWeek.Sunday
+        };
     }
 }

--- a/ExtraIsland/Components/ProfileInformation/ProfileInformation.axaml.cs
+++ b/ExtraIsland/Components/ProfileInformation/ProfileInformation.axaml.cs
@@ -55,32 +55,11 @@ public partial class ProfileInformation : ComponentBase<ProfileInformationConfig
     int GetWeekInSemester(DateTime? current = null) {
         current ??= _exactTimeService.GetCurrentLocalDateTime();
         DateTime orientation = (DateTime)((dynamic)AppBase.Current).Settings.SingleWeekStartTime;
-        
-        // 计算学期开始时间所在周的第一天（根据配置）
-        DayOfWeek firstDayOfWeek = ConvertToDayOfWeek(Settings.FirstDayOfWeek);
-        
-        // 计算从学期开始日期到本周第一天的天数差
-        int daysToStartOfWeek = ((int)orientation.DayOfWeek - (int)firstDayOfWeek + 7) % 7;
+        int daysToStartOfWeek = ((int)orientation.DayOfWeek - (int)Settings.FirstDayOfWeek + 7) % 7;
         DateTime startDay = orientation.AddDays(-daysToStartOfWeek);
-        
-        // 计算当前日期所在周的最后一天
-        int daysToEndOfWeek = ((int)firstDayOfWeek - (int)current.Value.DayOfWeek + 6) % 7;
+        int daysToEndOfWeek = ((int)Settings.FirstDayOfWeek - (int)current.Value.DayOfWeek + 6) % 7;
         DateTime lastEnd = current.Value.AddDays(daysToEndOfWeek);
-        
         TimeSpan totalWeekDelta = lastEnd - startDay;
         return Convert.ToInt32(totalWeekDelta.Days + 1) / 7;
-    }
-    
-    DayOfWeek ConvertToDayOfWeek(FirstDayOfWeek firstDayOfWeek) {
-        return firstDayOfWeek switch {
-            FirstDayOfWeek.Sunday => DayOfWeek.Sunday,
-            FirstDayOfWeek.Monday => DayOfWeek.Monday,
-            FirstDayOfWeek.Tuesday => DayOfWeek.Tuesday,
-            FirstDayOfWeek.Wednesday => DayOfWeek.Wednesday,
-            FirstDayOfWeek.Thursday => DayOfWeek.Thursday,
-            FirstDayOfWeek.Friday => DayOfWeek.Friday,
-            FirstDayOfWeek.Saturday => DayOfWeek.Saturday,
-            _ => DayOfWeek.Sunday
-        };
     }
 }

--- a/ExtraIsland/Components/ProfileInformation/ProfileInformationConfig.cs
+++ b/ExtraIsland/Components/ProfileInformation/ProfileInformationConfig.cs
@@ -12,7 +12,7 @@ public partial class ProfileInformationConfig : ObservableObject {
     bool _isShortModeEnabled;
     
     [ObservableProperty]
-    FirstDayOfWeek _firstDayOfWeek = FirstDayOfWeek.Sunday;
+    FirstDayOfWeek _firstDayOfWeek = FirstDayOfWeek.Monday;
 }
 
 public enum ProfileInformationType {

--- a/ExtraIsland/Components/ProfileInformation/ProfileInformationConfig.cs
+++ b/ExtraIsland/Components/ProfileInformation/ProfileInformationConfig.cs
@@ -10,6 +10,9 @@ public partial class ProfileInformationConfig : ObservableObject {
     
     [ObservableProperty]
     bool _isShortModeEnabled;
+    
+    [ObservableProperty]
+    FirstDayOfWeek _firstDayOfWeek = FirstDayOfWeek.Sunday;
 }
 
 public enum ProfileInformationType {
@@ -17,4 +20,21 @@ public enum ProfileInformationType {
     WeekOfSemester,
     [Description("单双周")]
     ParityOfWeek
+}
+
+public enum FirstDayOfWeek {
+    [Description("周日")]
+    Sunday,
+    [Description("周一")]
+    Monday,
+    [Description("周二")]
+    Tuesday,
+    [Description("周三")]
+    Wednesday,
+    [Description("周四")]
+    Thursday,
+    [Description("周五")]
+    Friday,
+    [Description("周六")]
+    Saturday
 }

--- a/ExtraIsland/Components/ProfileInformation/ProfileInformationConfig.cs
+++ b/ExtraIsland/Components/ProfileInformation/ProfileInformationConfig.cs
@@ -12,7 +12,7 @@ public partial class ProfileInformationConfig : ObservableObject {
     bool _isShortModeEnabled;
     
     [ObservableProperty]
-    FirstDayOfWeek _firstDayOfWeek = FirstDayOfWeek.Monday;
+    DayOfWeek _firstDayOfWeek = DayOfWeek.Monday;
 }
 
 public enum ProfileInformationType {
@@ -20,21 +20,4 @@ public enum ProfileInformationType {
     WeekOfSemester,
     [Description("单双周")]
     ParityOfWeek
-}
-
-public enum FirstDayOfWeek {
-    [Description("周日")]
-    Sunday,
-    [Description("周一")]
-    Monday,
-    [Description("周二")]
-    Tuesday,
-    [Description("周三")]
-    Wednesday,
-    [Description("周四")]
-    Thursday,
-    [Description("周五")]
-    Friday,
-    [Description("周六")]
-    Saturday
 }

--- a/ExtraIsland/Components/ProfileInformation/ProfileInformationSettings.axaml
+++ b/ExtraIsland/Components/ProfileInformation/ProfileInformationSettings.axaml
@@ -36,7 +36,7 @@
                     <ToggleSwitch IsChecked="{Binding Settings.IsShortModeEnabled, Mode=TwoWay}"/>
                 </controls:SettingsExpander.Footer>
             </controls:SettingsExpander>
-            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE787;}"
+            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE310;}"
                                        Header="每周第一天"
                                        Description="设置每周的第一天是周几">
                 <controls:SettingsExpander.Footer>

--- a/ExtraIsland/Components/ProfileInformation/ProfileInformationSettings.axaml
+++ b/ExtraIsland/Components/ProfileInformation/ProfileInformationSettings.axaml
@@ -8,6 +8,7 @@
                   x:TypeArguments="components:ProfileInformationConfig">
     <ci:ComponentBase.Resources>
         <converters:EnumDescriptionConverter x:Key="EnumDescriptionConverter" />
+        <converters:DayOfWeekEnumFullStringConverter x:Key="DayOfWeekEnumFullStringConverter"/>
     </ci:ComponentBase.Resources>
     <ScrollViewer
         DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=components:ProfileInformationSettings}}">
@@ -45,7 +46,7 @@
                         ItemsSource="{Binding FirstDayOfWeekOptions}">
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
-                                <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}" />
+                                <TextBlock Text="{Binding Converter={StaticResource DayOfWeekEnumFullStringConverter}}" />
                             </DataTemplate>
                         </ComboBox.ItemTemplate>
                     </ComboBox>

--- a/ExtraIsland/Components/ProfileInformation/ProfileInformationSettings.axaml
+++ b/ExtraIsland/Components/ProfileInformation/ProfileInformationSettings.axaml
@@ -35,6 +35,22 @@
                     <ToggleSwitch IsChecked="{Binding Settings.IsShortModeEnabled, Mode=TwoWay}"/>
                 </controls:SettingsExpander.Footer>
             </controls:SettingsExpander>
+            <controls:SettingsExpander IconSource="{ci:FluentIconSource &#xE787;}"
+                                       Header="每周第一天"
+                                       Description="设置每周的第一天是周几">
+                <controls:SettingsExpander.Footer>
+                    <ComboBox
+                        MinWidth="20"
+                        SelectedItem="{Binding Settings.FirstDayOfWeek, Mode=TwoWay}"
+                        ItemsSource="{Binding FirstDayOfWeekOptions}">
+                        <ComboBox.ItemTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding Converter={StaticResource EnumDescriptionConverter}}" />
+                            </DataTemplate>
+                        </ComboBox.ItemTemplate>
+                    </ComboBox>
+                </controls:SettingsExpander.Footer>
+            </controls:SettingsExpander>
             <Label HorizontalAlignment="Center" 
                    Foreground="{DynamicResource MaterialDesignBodyLight}">
                 Added by ExtraIsland

--- a/ExtraIsland/Components/ProfileInformation/ProfileInformationSettings.axaml.cs
+++ b/ExtraIsland/Components/ProfileInformation/ProfileInformationSettings.axaml.cs
@@ -11,4 +11,14 @@ public partial class ProfileInformationSettings : ComponentBase<ProfileInformati
         ProfileInformationType.WeekOfSemester,
         ProfileInformationType.ParityOfWeek
     ];
+
+    public List<FirstDayOfWeek> FirstDayOfWeekOptions { get; } = [
+        FirstDayOfWeek.Sunday,
+        FirstDayOfWeek.Monday,
+        FirstDayOfWeek.Tuesday,
+        FirstDayOfWeek.Wednesday,
+        FirstDayOfWeek.Thursday,
+        FirstDayOfWeek.Friday,
+        FirstDayOfWeek.Saturday
+    ];
 }

--- a/ExtraIsland/Components/ProfileInformation/ProfileInformationSettings.axaml.cs
+++ b/ExtraIsland/Components/ProfileInformation/ProfileInformationSettings.axaml.cs
@@ -12,13 +12,13 @@ public partial class ProfileInformationSettings : ComponentBase<ProfileInformati
         ProfileInformationType.ParityOfWeek
     ];
 
-    public List<FirstDayOfWeek> FirstDayOfWeekOptions { get; } = [
-        FirstDayOfWeek.Sunday,
-        FirstDayOfWeek.Monday,
-        FirstDayOfWeek.Tuesday,
-        FirstDayOfWeek.Wednesday,
-        FirstDayOfWeek.Thursday,
-        FirstDayOfWeek.Friday,
-        FirstDayOfWeek.Saturday
+    public List<DayOfWeek> FirstDayOfWeekOptions { get; } = [
+        DayOfWeek.Sunday,
+        DayOfWeek.Monday,
+        DayOfWeek.Tuesday,
+        DayOfWeek.Wednesday,
+        DayOfWeek.Thursday,
+        DayOfWeek.Friday,
+        DayOfWeek.Saturday
     ];
 }

--- a/ExtraIsland/Shared/Converters/Converters.cs
+++ b/ExtraIsland/Shared/Converters/Converters.cs
@@ -75,6 +75,27 @@ public class EnumDescriptionConverter : IValueConverter {
     }
 }
 
+public class DayOfWeekEnumFullStringConverter : IValueConverter {
+    object IValueConverter.Convert(object? value,Type targetType,object? parameter,CultureInfo culture) {
+        DayOfWeek day = (DayOfWeek)value!;
+        string description = day switch {
+            DayOfWeek.Sunday => "周日",
+            DayOfWeek.Monday => "周一",
+            DayOfWeek.Tuesday => "周二",
+            DayOfWeek.Wednesday => "周三",
+            DayOfWeek.Thursday => "周四",
+            DayOfWeek.Friday => "周五",
+            DayOfWeek.Saturday => "周六",
+            _ => "???"
+        };
+        return description;
+    }
+
+    object IValueConverter.ConvertBack(object? value,Type targetType,object? parameter,CultureInfo culture) {
+        return string.Empty;
+    }
+}
+
 public class DayOfWeekEnumStringConverter : IValueConverter {
     object IValueConverter.Convert(object? value,Type targetType,object? parameter,CultureInfo culture) {
         DayOfWeek day = (DayOfWeek)value!;


### PR DESCRIPTION
- 在档案信息组件中添加了每周第一天的设置选项
- 默认设置为周日，符合用户习惯
- 支持中文显示周几选项（周日、周一、周二、周三、周四、周五、周六）
- 确保周数计算正确反映用户设置的每周第一天
- 修复了周数计算逻辑，确保不同每周第一天设置下的计算准确性